### PR TITLE
Remove authn/authz from includeme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,21 +39,20 @@ Install the Python package:
     pip install cliquet-fxa
 
 
-Enable the authentication policy in configuration using `pyramid_multiauth
+Include the package in the project configuration:
+
+::
+
+    pyramid.includes = cliquet_fxa
+
+And configure authentication policy using `pyramid_multiauth
 <https://github.com/mozilla-services/pyramid_multiauth#deployment-settings>`_ formalism:
 
 ::
 
     multiauth.policies = fxa
-    # multiauth.policy.fxa.realm = Realm
 
 By default, it will rely on the cache configured in *Cliquet*.
-
-Enable heartbeat check and the API endpoints:
-
-::
-
-    pyramid.includes = cliquet_fxa
 
 
 Configuration
@@ -78,6 +77,14 @@ endpoints disabled):
 ::
 
     fxa-oauth.relier.enabled = false
+
+
+If necessary, override default values for authentication policy:
+
+::
+
+    # multiauth.policy.fxa.realm = Realm
+    # multiauth.policy.fxa.use = cliquet_fxa.authentication.FxAOAuthAuthenticationPolicy
 
 
 Login flow

--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,7 @@ Enable the authentication policy in configuration using `pyramid_multiauth
 ::
 
     multiauth.policies = fxa
+    # multiauth.policy.fxa.realm = Realm
 
 By default, it will rely on the cache configured in *Cliquet*.
 

--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,7 @@ It provides:
 
 * An authentication policy class;
 * Integration with *Cliquet* cache backend for token verifications;
+* Integration with *Cliquet* for heartbeat view checks;
 * Some endpoints to perform the *OAuth* dance (*optional*).
 
 
@@ -38,15 +39,21 @@ Install the Python package:
     pip install cliquet-fxa
 
 
-Enable in configuration using `pyramid_multiauth
+Enable the authentication policy in configuration using `pyramid_multiauth
 <https://github.com/mozilla-services/pyramid_multiauth#deployment-settings>`_ formalism:
 
 ::
 
     multiauth.policies = fxa
 
-
 By default, it will rely on the cache configured in *Cliquet*.
+
+Enable heartbeat check and the API endpoints:
+
+::
+
+    pyramid.includes = cliquet_fxa
+
 
 Configuration
 -------------

--- a/cliquet_fxa/__init__.py
+++ b/cliquet_fxa/__init__.py
@@ -1,8 +1,7 @@
 import cliquet
-from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.settings import asbool
 
-from cliquet_fxa.authentication import fxa_ping, FxAOAuthAuthenticationPolicy
+from cliquet_fxa.authentication import fxa_ping
 
 
 DEFAULT_SETTINGS = {
@@ -22,14 +21,6 @@ DEFAULT_SETTINGS = {
 def includeme(config):
     cliquet.load_default_settings(config, DEFAULT_SETTINGS)
     settings = config.get_settings()
-
-    authz_policy = ACLAuthorizationPolicy()
-    config.set_authorization_policy(authz_policy)
-
-    # Use the settings to construct an AuthenticationPolicy.
-    realm = settings['fxa-oauth.realm']
-    authn_policy = FxAOAuthAuthenticationPolicy(realm=realm)
-    config.set_authentication_policy(authn_policy)
 
     if hasattr(config.registry, 'heartbeats'):
         config.registry.heartbeats['oauth'] = fxa_ping

--- a/cliquet_fxa/__init__.py
+++ b/cliquet_fxa/__init__.py
@@ -5,12 +5,14 @@ from cliquet_fxa.authentication import fxa_ping
 
 
 DEFAULT_SETTINGS = {
+    'multiauth.policy.fxa.use': ('cliquet_fxa.authentication.'
+                                 'FxAOAuthAuthenticationPolicy'),
+    'multiauth.policy.fxa.realm': 'Realm',
     'fxa-oauth.cache_ttl_seconds': 5 * 60,
     'fxa-oauth.client_id': None,
     'fxa-oauth.client_secret': None,
     'fxa-oauth.heartbeat_timeout_seconds': 3,
     'fxa-oauth.oauth_uri': None,
-    'fxa-oauth.realm': 'Realm',
     'fxa-oauth.relier.enabled': True,
     'fxa-oauth.scope': 'profile',
     'fxa-oauth.state.ttl_seconds': 3600,  # 1 hour

--- a/cliquet_fxa/__init__.py
+++ b/cliquet_fxa/__init__.py
@@ -24,8 +24,12 @@ def includeme(config):
     cliquet.load_default_settings(config, DEFAULT_SETTINGS)
     settings = config.get_settings()
 
+    # Register heartbeat to ping FxA server.
     if hasattr(config.registry, 'heartbeats'):
         config.registry.heartbeats['oauth'] = fxa_ping
+
+    # Requires cornice to scan views.
+    config.include("cornice")
 
     # Ignore FxA OAuth relier endpoint in case it's not activated.
     relier_enabled = asbool(settings['fxa-oauth.relier.enabled'])

--- a/cliquet_fxa/tests/test_includeme.py
+++ b/cliquet_fxa/tests/test_includeme.py
@@ -1,10 +1,7 @@
 import cliquet
 from pyramid import testing
-from pyramid.authorization import ACLAuthorizationPolicy
-from pyramid.interfaces import IAuthenticationPolicy, IAuthorizationPolicy
 
 from cliquet_fxa import includeme
-from cliquet_fxa.authentication import FxAOAuthAuthenticationPolicy
 
 from . import unittest
 
@@ -16,22 +13,6 @@ class IncludeMeTest(unittest.TestCase):
         config.include(includeme)
         settings = config.get_settings()
         self.assertIsNotNone(settings.get('fxa-oauth.relier.enabled'))
-
-    def test_a_default_authorization_is_set(self):
-        config = testing.setUp()
-        cliquet.initialize(config, '0.0.1')
-        config.include(includeme)
-        config.commit()
-        policy = config.registry.queryUtility(IAuthorizationPolicy)
-        self.assertTrue(isinstance(policy, ACLAuthorizationPolicy))
-
-    def test_the_authentication_policy_is_set(self):
-        config = testing.setUp()
-        cliquet.initialize(config, '0.0.1')
-        config.include(includeme)
-        config.commit()
-        policy = config.registry.queryUtility(IAuthenticationPolicy)
-        self.assertTrue(isinstance(policy, FxAOAuthAuthenticationPolicy))
 
     def test_a_heartbeat_is_registered_at_oauth(self):
         config = testing.setUp()


### PR DESCRIPTION
At first, I had put these in ``includeme()`` because that's how it was done in pyramid_ipauth, pyramid_personna, etc...

I now wonder if this will integrate well with *Cliquet*, and would prefer this version of includeme(). 

What do you think ? @Natim @ametaireau r?