### PR TITLE
Force version prefix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,10 @@ This document describes changes between each past release.
 1.4.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**Breaking changes**
+
+- The views are now reachable using version prefix. If ``cliquet.version_prefix_redirect_enabled``
+  is false, `cliquet-fxa` will still expect a version prefix in URLs.
 
 
 1.3.2 (2015-10-22)

--- a/cliquet_fxa/tests/test_views.py
+++ b/cliquet_fxa/tests/test_views.py
@@ -87,17 +87,17 @@ class DeactivatedOAuthRelierTest(BaseWebTest, unittest.TestCase):
         return settings
 
     def test_login_view_is_not_available(self):
-        self.app.get('/fxa-oauth/login', status=404)
+        self.app.get('/v1/fxa-oauth/login', status=404)
 
     def test_params_view_is_still_available(self):
-        self.app.get('/fxa-oauth/params', status=200)
+        self.app.get('/v1/fxa-oauth/params', status=200)
 
     def test_token_view_is_not_available(self):
-        self.app.get('/fxa-oauth/token', status=404)
+        self.app.get('/v1/fxa-oauth/token', status=404)
 
 
 class LoginViewTest(BaseWebTest, unittest.TestCase):
-    url = '/fxa-oauth/login?redirect=https://readinglist.firefox.com'
+    url = '/v1/fxa-oauth/login?redirect=https://readinglist.firefox.com'
 
     def get_app_settings(self, additional_settings=None):
         additional_settings = additional_settings or {}
@@ -107,12 +107,12 @@ class LoginViewTest(BaseWebTest, unittest.TestCase):
         return super(LoginViewTest, self).get_app_settings(additional_settings)
 
     def test_redirect_parameter_is_mandatory(self):
-        url = '/fxa-oauth/login'
+        url = '/v1/fxa-oauth/login'
         r = self.app.get(url, status=400)
         self.assertIn('redirect', r.json['message'])
 
     def test_redirect_parameter_should_be_refused_if_not_whitelisted(self):
-        url = '/fxa-oauth/login?redirect=http://not-whitelisted.tld'
+        url = '/v1/fxa-oauth/login?redirect=http://not-whitelisted.tld'
         r = self.app.get(url, status=400)
         self.assertIn('redirect', r.json['message'])
 
@@ -120,14 +120,14 @@ class LoginViewTest(BaseWebTest, unittest.TestCase):
         with mock.patch.dict(self.app.app.registry.settings,
                              [('fxa-oauth.webapp.authorized_domains',
                                '*.whitelist.ed')]):
-            url = '/fxa-oauth/login?redirect=http://iam.whitelist.ed'
+            url = '/v1/fxa-oauth/login?redirect=http://iam.whitelist.ed'
             self.app.get(url)
 
     def test_redirect_parameter_should_be_rejected_if_no_whitelist(self):
         with mock.patch.dict(self.app.app.registry.settings,
                              [('fxa-oauth.webapp.authorized_domains',
                                '')]):
-            url = '/fxa-oauth/login?redirect=http://iam.whitelist.ed'
+            url = '/v1/fxa-oauth/login?redirect=http://iam.whitelist.ed'
             r = self.app.get(url, status=400)
         self.assertIn('redirect', r.json['message'])
 
@@ -176,7 +176,7 @@ class LoginViewTest(BaseWebTest, unittest.TestCase):
 
 
 class ParamsViewTest(BaseWebTest, unittest.TestCase):
-    url = '/fxa-oauth/params'
+    url = '/v1/fxa-oauth/params'
 
     def test_params_view_give_back_needed_values(self):
         settings = self.app.app.registry.settings
@@ -195,8 +195,8 @@ class ParamsViewTest(BaseWebTest, unittest.TestCase):
 
 
 class TokenViewTest(FormattedErrorMixin, BaseWebTest, unittest.TestCase):
-    url = '/fxa-oauth/token'
-    login_url = '/fxa-oauth/login?redirect=https://readinglist.firefox.com'
+    url = '/v1/fxa-oauth/token'
+    login_url = '/v1/fxa-oauth/login?redirect=https://readinglist.firefox.com'
 
     def __init__(self, *args, **kwargs):
         super(TokenViewTest, self).__init__(*args, **kwargs)

--- a/cliquet_fxa/views/params.py
+++ b/cliquet_fxa/views/params.py
@@ -6,7 +6,7 @@ from cliquet_fxa.utils import fxa_conf
 
 
 params = Service(name='fxa-oauth-params',
-                 path='/fxa-oauth/params',
+                 path='/v{version}/fxa-oauth/params',
                  error_handler=errors.json_error_handler)
 
 

--- a/cliquet_fxa/views/relier.py
+++ b/cliquet_fxa/views/relier.py
@@ -24,11 +24,11 @@ logger = logging.getLogger(__name__)
 
 
 login = Service(name='fxa-oauth-login',
-                path='/fxa-oauth/login',
+                path='/v{version}/fxa-oauth/login',
                 error_handler=json_error_handler)
 
 token = Service(name='fxa-oauth-token',
-                path='/fxa-oauth/token',
+                path='/v{version}/fxa-oauth/token',
                 error_handler=json_error_handler)
 
 


### PR DESCRIPTION
When cliquet-fxa is enabled via configuration (includes in .ini),
the cliquet initialization has not happened yet.

There the version prefix is not setup.

Currently, this means that cliquet-fxa views are accessible without
version prefix. Which leads to ugly code in client to reach them.

This PR brings the opposite approach. The views are only
reachable with version prefix. Which is what will happen in most
cases, and at Mozilla.


@Natim r?