### PR TITLE
Require cliquet to be initialized

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ This document describes changes between each past release.
 1.4.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+-  Updated to *Cliquet* 2.9.0
 
 
 1.3.2 (2015-10-22)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,13 +8,18 @@ This document describes changes between each past release.
 
 -  Updated to *Cliquet* 2.9.0
 
+**Breaking changes**
+
+- *cliquet-fxa* cannot be included using ``pyramid.includes`` setting.
+  Use ``cliquet.includes`` instead.
+
 
 1.3.2 (2015-10-22)
 ------------------
 
 **Bug fixes**
 
-- In case the Oauth dance is interrupted, return a ``408 Request Timeout`` 
+- In case the Oauth dance is interrupted, return a ``408 Request Timeout``
   error instead of the ``401 Unauthenticated`` one. (#11)
 - Do not call ``cliquet.load_default_settings`` from cliquet-fxa (#12)
 

--- a/README.rst
+++ b/README.rst
@@ -11,15 +11,15 @@ Firefox Accounts support in Cliquet
     :alt: Coverage
     :target: https://coveralls.io/r/mozilla-services/cliquet-fxa
 
-*Cliquet-fxa* enables authentication in *Cliquet* using *Firefox Accounts*
-OAuth2 bearer tokens.
+*Cliquet-fxa* enables authentication in *Cliquet* applications using
+*Firefox Accounts* OAuth2 bearer tokens.
 
 It provides:
 
 * An authentication policy class;
 * Integration with *Cliquet* cache backend for token verifications;
 * Integration with *Cliquet* for heartbeat view checks;
-* Some endpoints to perform the *OAuth* dance (*optional*).
+* Some optional endpoints to perform the *OAuth* dance (*optional*).
 
 
 * `Cliquet documentation <http://cliquet.readthedocs.org/en/latest/>`_
@@ -43,7 +43,7 @@ Include the package in the project configuration:
 
 ::
 
-    pyramid.includes = cliquet_fxa
+    cliquet.includes = cliquet_fxa
 
 And configure authentication policy using `pyramid_multiauth
 <https://github.com/mozilla-services/pyramid_multiauth#deployment-settings>`_ formalism:

--- a/cliquet_fxa/tests/test_authentication.py
+++ b/cliquet_fxa/tests/test_authentication.py
@@ -13,7 +13,7 @@ from . import unittest, DummyRequest
 
 class TokenVerificationCacheTest(unittest.TestCase):
     def setUp(self):
-        cache = memory_backend.Memory()
+        cache = memory_backend.Cache()
         self.cache = authentication.TokenVerificationCache(cache, 0.01)
 
     def test_set_adds_the_record(self):
@@ -38,7 +38,7 @@ class TokenVerificationCacheTest(unittest.TestCase):
 class FxAOAuthAuthenticationPolicyTest(unittest.TestCase):
     def setUp(self):
         self.policy = authentication.FxAOAuthAuthenticationPolicy()
-        self.backend = memory_backend.Memory()
+        self.backend = memory_backend.Cache()
 
         self.request = DummyRequest()
         self.request.registry.cache = self.backend

--- a/cliquet_fxa/tests/test_includeme.py
+++ b/cliquet_fxa/tests/test_includeme.py
@@ -1,5 +1,6 @@
 import cliquet
 import mock
+from pyramid.exceptions import ConfigurationError
 from pyramid import testing
 from pyramid.config import Configurator
 
@@ -9,6 +10,11 @@ from . import unittest
 
 
 class IncludeMeTest(unittest.TestCase):
+    def test_include_fails_if_cliquet_was_not_initialized(self):
+        config = testing.setUp()
+        with self.assertRaises(ConfigurationError):
+            config.include(includeme)
+
     def test_settings_are_filled_with_defaults(self):
         config = testing.setUp()
         cliquet.initialize(config, '0.0.1')

--- a/cliquet_fxa/tests/test_views.py
+++ b/cliquet_fxa/tests/test_views.py
@@ -66,8 +66,8 @@ class BaseWebTest(object):
 
     def get_app_settings(self, additional_settings=None):
         settings = cliquet.DEFAULT_SETTINGS.copy()
-        settings['cliquet.includes'] = 'fxa'
-        settings['multiauth.policies'] = 'cliquet_fxa'
+        settings['includes'] = 'cliquet_fxa'
+        settings['multiauth.policies'] = 'fxa'
         settings['cache_backend'] = 'cliquet.cache.memory'
         settings['cache_backend'] = 'cliquet.cache.memory'
         settings['userid_hmac_secret'] = random_bytes_hex(16)

--- a/cliquet_fxa/tests/test_views.py
+++ b/cliquet_fxa/tests/test_views.py
@@ -9,8 +9,6 @@ from pyramid.config import Configurator
 from six.moves.urllib.parse import parse_qs, urlparse
 from time import sleep
 
-from cliquet_fxa import includeme
-
 from . import unittest
 
 
@@ -64,11 +62,13 @@ class BaseWebTest(object):
     def _get_app_config(self, settings=None):
         config = Configurator(settings=self.get_app_settings(settings))
         cliquet.initialize(config, version='0.0.1')
-        config.include(includeme)
         return config
 
     def get_app_settings(self, additional_settings=None):
         settings = cliquet.DEFAULT_SETTINGS.copy()
+        settings['cliquet.includes'] = 'fxa'
+        settings['multiauth.policies'] = 'cliquet_fxa'
+        settings['cache_backend'] = 'cliquet.cache.memory'
         settings['cache_backend'] = 'cliquet.cache.memory'
         settings['userid_hmac_secret'] = random_bytes_hex(16)
         settings['fxa-oauth.relier.enabled'] = True

--- a/cliquet_fxa/views/relier.py
+++ b/cliquet_fxa/views/relier.py
@@ -15,7 +15,7 @@ from pyramid.settings import aslist
 from cliquet.errors import (
     http_error, ERRORS, json_error_handler, raise_invalid
 )
-from cliquet.schema import URL
+from cliquet.resource.schema import URL
 
 from cliquet_fxa.utils import fxa_conf
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with codecs.open(os.path.join(here, 'CONTRIBUTORS.rst'),
 
 
 REQUIREMENTS = [
-    'cliquet >= 2.8',
+    'cliquet >= 2.9',
     'pyfxa >= 0.0.9',
 ]
 


### PR DESCRIPTION
Rely on `cliquet.includes` to activate `cliquet-fxa`.

This superseeds #13 #15 #16 

- url prefix is properly transmitted from cliquet
- settings are initialize
- heartbeat attribute is set

Tests fail because it requires https://github.com/mozilla-services/cliquet/pull/504/files

@Natim r?
